### PR TITLE
Add configurable CLI for simulations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
 .venv
+venv
 
 .pytest_cache
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ Run the default four-way intersection simulation:
 python -m sim
 ```
 
+You can override parameters directly on the command line:
+
+``` bash
+python -m sim --duration 7200 \
+    --north-rate 0.05 --south-rate 0.05 \
+    --east-rate 0.08 --west-rate 0.07 \
+    --metrics-path results.json
+```
+
 ## Creating Custom Intersections
 
 You can create custom intersections by defining light configurations and phases:

--- a/sim/__main__.py
+++ b/sim/__main__.py
@@ -1,6 +1,71 @@
+import argparse
+import json
+from pathlib import Path
+
+from sim.basic_fourway_intersection import (
+    arrival_rates as default_rates,
+    duration as default_duration,
+    intersection,
+)
 from sim.intersection import simulate
-from sim.basic_fourway_intersection import intersection, arrival_rates
+from sim.models.lights import Direction
 
-stats = simulate(1000, intersection, arrival_rates)
 
-stats.show_summary()
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description='Traffic light simulation')
+    parser.add_argument(
+        '--duration',
+        type=int,
+        default=default_duration,
+        help='Simulation duration in seconds',
+    )
+    parser.add_argument(
+        '--north-rate',
+        type=float,
+        default=default_rates[Direction.NORTH],
+        help='Northbound arrival rate (vehicles/sec)',
+    )
+    parser.add_argument(
+        '--south-rate',
+        type=float,
+        default=default_rates[Direction.SOUTH],
+        help='Southbound arrival rate (vehicles/sec)',
+    )
+    parser.add_argument(
+        '--east-rate',
+        type=float,
+        default=default_rates[Direction.EAST],
+        help='Eastbound arrival rate (vehicles/sec)',
+    )
+    parser.add_argument(
+        '--west-rate',
+        type=float,
+        default=default_rates[Direction.WEST],
+        help='Westbound arrival rate (vehicles/sec)',
+    )
+    parser.add_argument(
+        '--metrics-path',
+        type=Path,
+        help='Path to write summary metrics as JSON',
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    rates = {
+        Direction.NORTH: args.north_rate,
+        Direction.SOUTH: args.south_rate,
+        Direction.EAST: args.east_rate,
+        Direction.WEST: args.west_rate,
+    }
+
+    stats = simulate(args.duration, intersection, rates)
+    stats.show_summary()
+
+    if args.metrics_path:
+        args.metrics_path.write_text(json.dumps(stats.to_dict(), indent=2))
+
+
+if __name__ == '__main__':
+    main()

--- a/sim/models/metrics.py
+++ b/sim/models/metrics.py
@@ -41,6 +41,19 @@ class SummaryStatistics:
         plt.hist(self.waiting_times)
         plt.show()
 
+    def to_dict(self) -> dict:
+        """Return summary statistics as a serializable dictionary."""
+        return {
+            'total_vehicles': self.total_vehicles,
+            'average_waiting_time': self.average_waiting_time(),
+            'max_waiting_time': self.max_waiting_time(),
+            'min_waiting_time': self.min_waiting_time(),
+            'median_waiting_time': self.median_waiting_time(),
+            'std_waiting_time': self.standard_deviation_waiting_time(),
+            'variance_waiting_time': self.variance_waiting_time(),
+            'total_waiting_time': self.total_waiting_time(),
+        }
+
     def show_summary(self, include_plot: bool = False):
         print(
             f'Total vehicles:           {self.total_vehicles:.2f}\n'

--- a/sim/models/vehicles.py
+++ b/sim/models/vehicles.py
@@ -1,4 +1,5 @@
 from sim.models.lights import Direction
 
 
-type ArrivalRates = dict[Direction, float]
+# Type alias for per-direction arrival rates
+ArrivalRates = dict[Direction, float]


### PR DESCRIPTION
## Summary
- add `ArrivalRates` type alias for Python 3.11
- expose `SummaryStatistics.to_dict` helper
- implement new CLI in `sim/__main__.py`
- document CLI options in README
- ignore `venv` directory in git

## Testing
- `pytest -xvs tests/test_traffic_patterns.py`