### PR TITLE
Add CSV export for stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ __pycache__
 
 .DS_Store
 *.DS_Store
+*.csv
+!tests/test.csv

--- a/sim/models/metrics.py
+++ b/sim/models/metrics.py
@@ -3,6 +3,8 @@ import numpy as np
 import numpy.typing as npt
 from pydantic import ConfigDict
 from pydantic.dataclasses import dataclass, Field
+import pandas as pd
+from pathlib import Path
 
 
 @dataclass(config=ConfigDict(arbitrary_types_allowed=True))
@@ -53,6 +55,18 @@ class SummaryStatistics:
             'variance_waiting_time': self.variance_waiting_time(),
             'total_waiting_time': self.total_waiting_time(),
         }
+
+    def to_csv(self, file_path: str | Path) -> None:
+        """Write the summary statistics to ``file_path`` as CSV.
+
+        Parameters
+        ----------
+        file_path : str | Path
+            Destination CSV path. Any parent directories must already exist.
+        """
+
+        df = pd.DataFrame([self.to_dict()])
+        df.to_csv(Path(file_path), index=False)
 
     def show_summary(self, include_plot: bool = False):
         print(

--- a/tests/test.csv
+++ b/tests/test.csv
@@ -1,0 +1,2 @@
+total_vehicles,average_waiting_time,max_waiting_time,min_waiting_time,median_waiting_time,std_waiting_time,variance_waiting_time,total_waiting_time
+6,12.0,35.0,0.0,6.5000000000000036,13.576941236277534,184.33333333333334,72.0

--- a/tests/test_export_metrics.py
+++ b/tests/test_export_metrics.py
@@ -1,0 +1,20 @@
+import pandas as pd
+from pathlib import Path
+
+from sim.intersection import simulate
+import numpy as np
+from sim.basic_fourway_intersection import intersection, arrival_rates
+from sim.traffic_patterns import TrafficPatternManager
+
+
+def test_to_csv(tmp_path):
+    np.random.seed(42)
+    manager = TrafficPatternManager(arrival_rates)
+    stats = simulate(100, intersection, traffic_manager=manager, start_time=0)
+    output = tmp_path / "out.csv"
+    stats.to_csv(output)
+
+    expected_path = Path(__file__).with_name("test.csv")
+    df_expected = pd.read_csv(expected_path)
+    df_actual = pd.read_csv(output)
+    pd.testing.assert_frame_equal(df_actual, df_expected)


### PR DESCRIPTION
## Summary
- extend `SummaryStatistics` with `to_csv` method
- ignore generated CSV files
- create `tests/test.csv` fixture
- test `to_csv` export against expected data

## Testing
- `pytest -xvs`